### PR TITLE
Fix missing initial value for nvim path

### DIFF
--- a/godot/addons/vimdow/vimdow.gd
+++ b/godot/addons/vimdow/vimdow.gd
@@ -23,6 +23,7 @@ func _enter_tree() -> void:
 		var full_setting = "vimdow/" + setting
 		if not ProjectSettings.has_setting(full_setting):
 			ProjectSettings.set_setting(full_setting, DEFAULT_SETTINGS[setting])
+		ProjectSettings.set_initial_value(full_setting, DEFAULT_SETTINGS[setting])
 	
 	editor = EDITOR.instantiate()
 	EditorInterface.get_editor_main_screen().add_child(editor)


### PR DESCRIPTION
Currently, the nvim path setting does not set an initial value, which means that clicking the revert button gives users a `null` value instead of `/usr/bin/nvim`.

To fix this, we have to use [`ProjectSettings.set_initial_value`](https://docs.godotengine.org/en/4.6/classes/class_projectsettings.html#class-projectsettings-method-set-initial-value).

<details><summary>Comparison when clicking the reset button on the option</summary>
<p>

Before:

<img width="1250" height="787" alt="Image" src="https://github.com/user-attachments/assets/2058d879-149e-41e5-81ae-78b5264a40ee" />

After:

<img width="1250" height="787" alt="image" src="https://github.com/user-attachments/assets/ff0de7ca-4fa4-4e3c-a4a8-3a97622464d9" />

</p>
</details> 

