### PR TITLE
Improve LSP configuration

### DIFF
--- a/godot/addons/vimdow/lua/vimdow.lua
+++ b/godot/addons/vimdow/lua/vimdow.lua
@@ -1,23 +1,18 @@
+local cfg = vim.lsp.config["gdscript"]
+local markers = (cfg and cfg.root_markers) or { "project.godot" }
+
 _G.Vimdow = {
-	is_godot_project = false,
+	is_godot_project = vim.fs.root(0, markers) ~= nil,
 }
 
-local root_dir = vim.fs.root(0, { "project.godot" })
-Vimdow.is_godot_project = root_dir ~= nil
+-- if set, overrides nvim-lspconfig's default port (6005)
+local langserver_port = os.getenv "GODOT_LANGSERVER_PORT"
 
-if Vimdow.is_godot_project then
-	-- Automatically connect to the language server
-	local langserver_port = os.getenv("GODOT_LANGSERVER_PORT")
-	vim.api.nvim_create_autocmd("FileType", {
-		pattern = { "gdscript", "gd" },
-		callback = function ()
-			local cmd = vim.lsp.rpc.connect("127.0.0.1", tonumber(langserver_port))
-			vim.lsp.start {
-				name = "gdscript",
-				cmd = cmd,
-				root_dir = root_dir,
-				filetypes = { "gdscript", "gd" },
-			}
-		end,
+if langserver_port then
+	vim.lsp.config("gdscript", {
+		cmd = vim.lsp.rpc.connect("127.0.0.1", tonumber(langserver_port)),
 	})
 end
+
+-- NOTE: this will only activate based on filetypes and root_markers
+vim.lsp.enable "gdscript"

--- a/godot/addons/vimdow/lua/vimdow.lua
+++ b/godot/addons/vimdow/lua/vimdow.lua
@@ -13,7 +13,7 @@ if Vimdow.is_godot_project then
 		callback = function ()
 			local cmd = vim.lsp.rpc.connect("127.0.0.1", tonumber(langserver_port))
 			vim.lsp.start {
-				name = "godot",
+				name = "gdscript",
 				cmd = cmd,
 				root_dir = root_dir,
 				filetypes = { "gdscript", "gd" },


### PR DESCRIPTION
Most of the current `gdscript` LSP configuration is already being taken care of by Neovim's defaults[^1]. To keep things clean and simple, we can just use that and override it as needed.

<details><summary>Comparison</summary>
<p>

Previously, we can see that 2 LSPs are attached to the buffer (`:checkhealth vim.lsp`):

```
vim.lsp: Active Clients ~
- godot (id: 1)
  - Version: ? (no serverInfo.version response)
  - Root directory: ~/Files/System/Documents/Godot 4/template
  - Command: <function @/nix/store/p3cpz8p3ykz8q8mmp4rpa5mzw6gkkp13-neovim-unwrapped-0.12.1/share/nvim/runtime/lua/vim/lsp/rpc.lua:626>
  - Settings: {}
  - Attached buffers: 2
- gdscript (id: 2)
  - Version: ? (no serverInfo.version response)
  - Root directory: ~/Files/System/Documents/Godot 4/template
  - Command: <function @/nix/store/p3cpz8p3ykz8q8mmp4rpa5mzw6gkkp13-neovim-unwrapped-0.12.1/share/nvim/runtime/lua/vim/lsp/rpc.lua:626>
  - Settings: {}
  - Attached buffers: 2
```

Aside from wasting resources, this may also lead to conflicts. For example, I've had instances where autocomplete items would be duplicated:

<img width="1310" height="270" alt="image" src="https://github.com/user-attachments/assets/075439ac-ea7a-464d-ad16-61b992644a66" />

After the changes in this PR, only 1 LSP is attached:

```
vim.lsp: Active Clients ~
- gdscript (id: 1)
  - Version: ? (no serverInfo.version response)
  - Root directory: ~/Files/System/Documents/Godot 4/template
  - Command: <function @/nix/store/p3cpz8p3ykz8q8mmp4rpa5mzw6gkkp13-neovim-unwrapped-0.12.1/share/nvim/runtime/lua/vim/lsp/rpc.lua:626>
  - Settings: {}
  - Attached buffers: 2
```

And it works as you'd expect:

<img width="1310" height="270" alt="image" src="https://github.com/user-attachments/assets/c4fc5fee-0a0f-4c5c-8576-c12e91c3e4f6" />

**PS:** I tested:

- only vimdow's LSP enabled
- only my personal Neovim config's LSP enabled
- both enabled simultaneously

In all cases, only 1 LSP was attached.

</p>
</details> 

[^1]: https://github.com/neovim/nvim-lspconfig/blob/cb5bc0b2b35a6d513e3298d285db81453e791f4f/lsp/gdscript.lua