### PR TITLE
docs: add neovim requirements note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Vimdow aims to provide this accessibility to Godot developers!
 
 ## Configuration
 
+**Requirements**: Neovim 0.11 or later.
+
 Vimdow only needs to know where Neovim's binary is located on your system to get working. By default both modes assume 
 that your on linux and set the path to `/usr/bin/nvim`
 


### PR DESCRIPTION
It's better to explicitly specify this since the Neovim API we're currently using is only supported starting from version 0.11:

https://neovim.io/doc/user/lsp/#vim.lsp.start()