### PR TITLE
feat: auto-open root script on scene change

### DIFF
--- a/godot/addons/vimdow/vimdow.gd
+++ b/godot/addons/vimdow/vimdow.gd
@@ -13,7 +13,10 @@ var debugger: VimdowDebugger
 var pop_out_shortcut: Shortcut
 var focus_shortcut: Shortcut
 
-const DEFAULT_SETTINGS = { }
+const DEFAULT_SETTINGS = {
+	"auto_open_root_script": true,
+	"auto_focus_on_scene_change": true,
+}
 
 func _enter_tree() -> void:
 	if DisplayServer.get_name() == "headless": # CI/CD sanity check
@@ -64,6 +67,7 @@ func _enter_tree() -> void:
 	_make_visible(false)
 
 	main_screen_changed.connect(_on_main_screen_changed)
+	scene_changed.connect(_on_scene_changed)
 
 	debugger = VimdowDebugger.new()
 	debugger.setup(editor)
@@ -97,6 +101,8 @@ func _on_neovim_request(msgid: int, method: String, params: Array):
 
 
 func _exit_tree() -> void:
+	if scene_changed.is_connected(_on_scene_changed):
+		scene_changed.disconnect(_on_scene_changed)
 	if editor:
 		editor.client.kill_process()
 		editor.queue_free()
@@ -137,6 +143,18 @@ func _on_editor_window_close():
 func _on_main_screen_changed(screen_name: String):
 	if screen_name != _get_plugin_name():
 		_last_main_screen = screen_name
+
+
+func _on_scene_changed(scene_root: Node) -> void:
+	if not ProjectSettings.get_setting("vimdow/auto_open_root_script", true):
+		return
+	if scene_root == null:
+		return
+	var script = scene_root.get_script()
+	if script and script.resource_path.begins_with("res://"):
+		editor.open_file(ProjectSettings.globalize_path(script.resource_path))
+		if ProjectSettings.get_setting("vimdow/auto_focus_on_scene_change", true):
+			editor.grab_focus()
 
 
 func _handles(object: Object) -> bool:


### PR DESCRIPTION
I added a scene_changed handler that automatically opens a scene's root script when switching scenes in the editor.

- New `auto_open_root_script` setting (default: true)
- New `auto_focus_on_scene_change` setting (default: true)
- Safe disconnect with `is_connected` guard in `_exit_tree`

I found I was constantly opening the script as I switched tabs in Godot. So this makes life easier and thought I'd contribute. Let me know if this fits into your vision, or needs any changes.